### PR TITLE
Remove unneeded logging and fix typo

### DIFF
--- a/detector/file_detector.go
+++ b/detector/file_detector.go
@@ -57,7 +57,6 @@ func FindConfig(searchDir string) (map[string][]string, error) {
 	for file, dir := range filesToCheck {
 		filePaths, err := searchFile(filepath.Join(searchDir, dir), file)
 		if err != nil {
-			fmt.Println("WARNING:", err)
 			continue
 		}
 		for _, filePath := range filePaths {

--- a/utility/path_utils.go
+++ b/utility/path_utils.go
@@ -106,8 +106,7 @@ func MakePshConfigPath(rootPath string, app string) (string, string) {
 	return pshDstAppPath, pshDstPath
 }
 
-func TransfertConfigCustom(src string, dst string) {
-	log.Println("Move custom config...")
+func TransferConfigCustom(src string, dst string) {
 	absProjectSourceConfig := filepath.Join(src, PSH_CONFIG_PATH)
 	dirs, _ := ListDir(absProjectSourceConfig)
 	for _, dir := range dirs {

--- a/utility/path_utils_test.go
+++ b/utility/path_utils_test.go
@@ -190,13 +190,13 @@ func TestGetFile(t *testing.T) {
 	assert.True(IsExist(dst))
 }
 
-func TestTransfertConfigCustom(t *testing.T) {
+func TestTransferConfigCustom(t *testing.T) {
 	assert := assert.New(t)
 	ws := BuildTemporyWorkspace()
 	defer ws.CleanUp()
 
 	src := path.Join(TEST_CONVERT_PATH, "project-psh")
 	dst := ws.Root
-	TransfertConfigCustom(src, dst)
+	TransferConfigCustom(src, dst)
 	assert.True(IsExist(path.Join(dst, "solr-config")))
 }


### PR DESCRIPTION
* remove calls to `fmt.Println`
* fix typo in `TransferConfigCustom`